### PR TITLE
Fix links in metadata and documentation

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,9 @@
   "author": "tailoredautomation",
   "summary": "Install and manages Patroni for high-availability PostgreSQL",
   "license": "Apache-2.0",
-  "source": "https://github.com/tailored-automation/puppet-patroni",
-  "project_page": "https://github.com/tailored-automation/puppet-patroni",
-  "issues_url": "https://github.com/tailored-automation/puppet-patroni/issues",
+  "source": "https://github.com/tailored-automation/puppet-module-patroni",
+  "project_page": "https://github.com/tailored-automation/puppet-module-patroni",
+  "issues_url": "https://github.com/tailored-automation/puppet-module-patroni/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
These are from the change in ownership from Jadestorm to Tailored
Automation.