### PR TITLE
Fix unit tests and simplify using custom virtualenv

### DIFF
--- a/spec/classes/patroni_spec.rb
+++ b/spec/classes/patroni_spec.rb
@@ -401,29 +401,20 @@ describe 'patroni' do
           expect(content).to include('ExecStart=/usr/local/patroni/bin/patroni ${PATRONI_CONFIG_LOCATION}')
         end
       end
-    end
 
-    context 'use_custom_virtualenv => true and custom_virtual unspecified (default value)' do
-      let(:params) { { 'scope' => 'testscope', 'use_custom_virtualenv' => true } }
+      context 'custom_virtualenv specified (/some/path)' do
+        let(:params) { { 'scope' => 'testscope', 'custom_virtualenv' => '/some/path' } }
 
-      it { is_expected.to compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-      it do
-        is_expected.to contain_python__pip('patroni').with(
-          virtualenv: nil,
+        it { is_expected.not_to contain_python__virtualenv('patroni') }
+        it { is_expected.not_to contain_python__pyvenv('patroni') }
+
+        it do
+          is_expected.to contain_python__pip('patroni').with(
+            virtualenv: '/some/path',
         )
-      end
-    end
-
-    context 'use_custom_virtualenv => true and custom_virtualenv specified (/some/path)' do
-      let(:params) { { 'scope' => 'testscope', 'use_custom_virtualenv' => true, 'custom_virtualenv' => '/some/path' } }
-
-      it { is_expected.to compile.with_all_deps }
-
-      it do
-        is_expected.to contain_python__pip('patroni').with(
-          virtualenv: '/some/path',
-        )
+        end
       end
     end
   end


### PR DESCRIPTION
Main change is one less parameter to use custom virtualenv.  If you pass `undef` to virtualenv, that doesn't mean no value, it means you use python module default which is `"system"` so it's not undefined, it's just not defined in Patroni module so falls back to Python module default. If the goal is to provide a custom virtualenv path as opt-in, then only 1 parameter is needed rather than having to set 2 to get the same result.

The reason unit tests were failing is the contexts for new parameters were outside the context setting the OS facts, since it's completely valid to have nested contexts, just moved the new tests inside the OS fact context block.

Also removed management of this module adding virtualenv if a custom one is used since doesn't make sense to continue using this module's virtualenv if a custom one is supplied.