### PR TITLE
Adding support for certificate authentication

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -18,7 +18,7 @@ fixtures:
     systemd:
       repo: https://github.com/camptocamp/puppet-systemd.git
     yumrepo_core:
-      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core
       puppet_version: ">= 6.0.0"
   symlinks:
     patroni: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,7 +24,7 @@ fixtures:
       repo: https://github.com/camptocamp/puppet-systemd.git
       ref: 2.0.0
     yumrepo_core:
-      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
       puppet_version: ">= 6.0.0"
   symlinks:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,8 +47,18 @@ The following parameters are available in the `patroni` class:
 * [`bootstrap_post_init`](#bootstrap_post_init)
 * [`superuser_username`](#superuser_username)
 * [`superuser_password`](#superuser_password)
+* [`superuser_sslmode`](#superuser_sslmode)
+* [`superuser_sslkey`](#superuser_sslkey)
+* [`superuser_sslpassword`](#superuser_sslpassword)
+* [`superuser_sslcert`](#superuser_sslcert)
+* [`superuser_sslrootcert`](#superuser_sslrootcert)
 * [`replication_username`](#replication_username)
 * [`replication_password`](#replication_password)
+* [`replication_sslmode`](#replication_sslmode)
+* [`replication_sslkey`](#replication_sslkey)
+* [`replication_sslpassword`](#replication_sslpassword)
+* [`replication_sslcert`](#replication_sslcert)
+* [`replication_sslrootcert`](#replication_sslrootcert)
 * [`callback_on_reload`](#callback_on_reload)
 * [`callback_on_restart`](#callback_on_restart)
 * [`callback_on_role_change`](#callback_on_role_change)
@@ -330,13 +340,53 @@ Default value: `'postgres'`
 
 ##### <a name="superuser_password"></a>`superuser_password`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Refer to PostgreSQL configuration settings superuser password
 
 Default value: `'changeme'`
 
-##### <a name="replication_username"></a>`replication_username`
+##### <a name="superuser_sslmode"><a/>superuser_sslmode
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings superuser sslmode
+
+Default value: ``undef``
+
+##### <a name="superuser_sslkey"><a/>superuser_sslkey
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings superuser sslkey
+
+Default value: ``undef``
+
+##### <a name="superuser_sslpassword"><a/>superuser_sslpassword
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings superuser sslpassword
+
+Default value: ``undef``
+
+##### <a name="superuser_sslcert"><a/>superuser_sslcert
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings superuser sslcert
+
+Default value: ``undef``
+
+##### <a name="superuser_sslrootcert"><a/>superuser_sslrootcert
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings superuser sslrootcert
+
+Default value: ``undef``
+
+##### <a name="replication_username"><a/>replication_username
 
 Data type: `String`
 
@@ -346,11 +396,51 @@ Default value: `'rep_user'`
 
 ##### <a name="replication_password"></a>`replication_password`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Refer to PostgreSQL configuration settings replication password
 
 Default value: `'changeme'`
+
+##### <a name="replication_sslmode"><a/>replication_sslmode
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings replication sslmode
+
+Default value: ``undef``
+
+##### <a name="replication_sslkey"><a/>replication_sslkey
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings replication sslkey
+
+Default value: ``undef``
+
+##### <a name="replication_sslpassword"><a/>replication_sslpassword
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings replication sslpassword
+
+Default value: ``undef``
+
+##### <a name="replication_sslcert"><a/>replication_sslcert
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings replication sslcert
+
+Default value: ``undef``
+
+##### <a name="replication_sslrootcert"><a/>replication_sslrootcert
+
+Data type: `Optional[String]`
+
+Refer to PostgreSQL configuration settings replication sslrootcert
+
+Default value: ``undef``
 
 ##### <a name="callback_on_reload"></a>`callback_on_reload`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,10 +48,30 @@
 #   Refer to PostgreSQL configuration settings superuser username
 # @param superuser_password
 #   Refer to PostgreSQL configuration settings superuser password
+# @param superuser_sslmode
+#   Refer to PostgreSQL configuration setting superuser sslmode
+# @param superuser_sslkey
+#   Refer to PostgreSQL configuration setting superuser sslkey
+# @param superuser_sslpassword
+#   Refer to PostgreSQL configuration setting superuser sslpassword
+# @param superuser_sslcert
+#   Refer to PostgreSQL configuration setting superuser sslcert
+# @param superuser_sslrootcert
+#   Refer to PostgreSQL configuration setting superuser sslrootcert
 # @param replication_username
 #   Refer to PostgreSQL configuration settings replication username
 # @param replication_password
 #   Refer to PostgreSQL configuration settings replication password
+# @param replication_sslmode
+#   Refer to PostgreSQL configuration setting replication sslmode
+# @param replication_sslkey
+#   Refer to PostgreSQL configuration setting replication sslkey
+# @param replication_sslpassword
+#   Refer to PostgreSQL configuration setting replication sslpassword
+# @param replication_sslcert
+#   Refer to PostgreSQL configuration setting replication sslcert
+# @param replication_sslrootcert
+#   Refer to PostgreSQL configuration setting replication sslrootcert
 # @param callback_on_reload
 #   Refer to PostgreSQL configuration settings callbacks `on_reload`
 # @param callback_on_restart
@@ -273,9 +293,19 @@ class patroni (
 
   # PostgreSQL Settings
   String $superuser_username = 'postgres',
-  String $superuser_password = 'changeme',
+  Optional[String] $superuser_password = 'changeme',
+  Optional[String] $superuser_sslmode = undef,
+  Optional[String] $superuser_sslkey = undef,
+  Optional[String] $superuser_sslpassword = undef,
+  Optional[String] $superuser_sslcert = undef,
+  Optional[String] $superuser_sslrootcert = undef,
   String $replication_username = 'rep_user',
-  String $replication_password = 'changeme',
+  Optional[String] $replication_password = 'changeme',
+  Optional[String] $replication_sslmode = undef,
+  Optional[String] $replication_sslkey = undef,
+  Optional[String] $replication_sslpassword = undef,
+  Optional[String] $replication_sslcert = undef,
+  Optional[String] $replication_sslrootcert = undef,
   Variant[Undef,String] $callback_on_reload = undef,
   Variant[Undef,String] $callback_on_restart = undef,
   Variant[Undef,String] $callback_on_role_change = undef,

--- a/spec/classes/patroni_spec.rb
+++ b/spec/classes/patroni_spec.rb
@@ -345,6 +345,67 @@ describe 'patroni' do
         end
       end
 
+      context 'superuser certificate authentication' do
+        let(:params) do
+          {
+            'scope'                 => 'testscope',
+            'superuser_username'    => 'superuser',
+            'superuser_sslmode'     => 'require',
+            'superuser_sslkey'      => '/var/lib/pgsql/ssl_key.pem',
+            'superuser_sslpassword' => 'secretpass',
+            'superuser_sslcert'     => '/var/lib/pgsql/ssl_cert.pem',
+            'superuser_sslrootcert' => '/var/lib/pgsql/root_cert.pem',
+          }
+        end
+
+        it 'has valid config' do
+          content = catalogue.resource('file', 'patroni_config').send(:parameters)[:content]
+          config = YAML.safe_load(content)
+          expected = {
+            'superuser' => {
+              'sslcert'     => '/var/lib/pgsql/ssl_cert.pem',
+              'sslkey'      => '/var/lib/pgsql/ssl_key.pem',
+              'sslmode'     => 'require',
+              'sslpassword' => 'secretpass',
+              'sslrootcert' => '/var/lib/pgsql/root_cert.pem',
+              'username'    => 'superuser',
+            },
+          }
+          expect(config).to include(expected)
+        end
+      end
+
+      context 'replication user certificate authentication' do
+        let(:params) do
+          {
+            'scope'                 => 'testscope',
+            'replication_username'    => 'replication',
+            'replication_sslmode'     => 'require',
+            'replication_sslkey'      => '/var/lib/pgsql/ssl_key.pem',
+            'replication_sslpassword' => 'secretpass',
+            'replication_sslcert'     => '/var/lib/pgsql/ssl_cert.pem',
+            'replication_sslrootcert' => '/var/lib/pgsql/root_cert.pem',
+          }
+        end
+
+        it 'has valid config' do
+          content = catalogue.resource('file', 'patroni_config').send(:parameters)[:content]
+          config = YAML.safe_load(content)
+          expected = {
+            "replication" => {
+              "username"    => "replication",
+              "password"    => "changeme",
+              "sslmode"     => "require",
+              "sslkey"      => "/var/lib/pgsql/ssl_key.pem",
+              "sslpassword" => "secretpass",
+              "sslcert"     => "/var/lib/pgsql/ssl_cert.pem",
+              "sslrootcert" =>"/var/lib/pgsql/root_cert.pem"
+            }
+          }
+          expect(config).to include(expected)
+        end
+      end
+
       context 'install_method => package' do
         let(:params) { { 'scope' => 'testscope', 'install_method' => 'package' } }
 

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -79,10 +79,44 @@ postgresql:
   authentication:
     superuser:
       username: <%= @superuser_username %>
+<% if @superuser_password != nil -%>
       password: <%= @superuser_password %>
+<% end -%>
+<% if @superuser_sslmode != nil -%>
+      sslmode: <%= @superuser_sslmode %>
+<% end -%>
+<% if @superuser_sslkey != nil -%>
+      sslkey: <%= @superuser_sslkey %>
+<% end -%>
+<% if @superuser_sslpassword != nil -%>
+      sslpassword: <%= @superuser_sslpassword %>
+<% end -%>
+<% if @superuser_sslcert != nil -%>
+      sslcert: <%= @superuser_sslcert %>
+<% end -%>
+<% if @superuser_sslrootcert != nil -%>
+      sslrootcert: <%= @superuser_sslrootcert %>
+<% end -%>
     replication:
       username: <%= @replication_username %>
+<% if @replication_password != nil -%>
       password: <%= @replication_password %>
+<% end -%>
+<% if @replication_sslmode != nil -%>
+      sslmode: <%= @replication_sslmode %>
+<% end -%>
+<% if @replication_sslkey != nil -%>
+      sslkey: <%= @replication_sslkey %>
+<% end -%>
+<% if @replication_sslpassword != nil -%>
+      sslpassword: <%= @replication_sslpassword %>
+<% end -%>
+<% if @replication_sslcert != nil -%>
+      sslcert: <%= @replication_sslcert %>
+<% end -%>
+<% if @replication_sslrootcert != nil -%>
+      sslrootcert: <%= @replication_sslrootcert %>
+<% end -%>
 <% unless @callback_on_reload == nil && @callback_on_restart == nil && @callback_on_role_change == nil && @callback_on_start == nil && @callback_on_stop == nil -%>
   callbacks:
 <% if @callback_on_reload != nil -%>


### PR DESCRIPTION
The supersuser and replication user now support setting authentication
with certificates. Made the password non required anymore (default is
still present).

Fixed the yumrepo_core git url, this caused the tests to fail.