### PR TITLE
Fix improper parsing of pgsql_replica_method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,7 +283,7 @@ class patroni (
   Variant[Undef,String] $callback_on_role_change = undef,
   Variant[Undef,String] $callback_on_start = undef,
   Variant[Undef,String] $callback_on_stop = undef,
-  String $pgsql_connect_address = "${facts['networking']['fqdn']}:5432",
+  Variant[Undef,String] $pgsql_connect_address = "${facts['networking']['fqdn']}:5432",
   Array[String] $pgsql_create_replica_methods = ['basebackup'],
   Optional[Stdlib::Unixpath] $pgsql_data_dir = undef,
   Variant[Undef,String] $pgsql_config_dir = undef,

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -130,10 +130,12 @@ postgresql:
 <% end -%>
 <% unless @pgsql_replica_method.empty? -%>
   replica_method:
-<% @pgsql_replica_method.each do |name,settings| -%>
+<% @pgsql_replica_method.each do |replica_method| -%>
+<% replica_method.each do |name, settings| -%>
     <%= name -%>:
 <% settings.each do |setname,setval| -%>
       <%= setname -%>: <%= setval %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Directly parsing key and value from array of hashes won't work, we need to first iterate through array and then split key and value in each array member

Hiera:

```
patroni::pgsql_replica_method:
  - wal_g:
      foo: 'bar'
```

Output with `2.0.0` from forge:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template patroni/postgresql.yml.erb:
  Filepath: /etc/puppetlabs/code/environments/MY_ENV/modules/patroni/templates/postgresql.yml.erb
  Line: 135
  Detail: undefined method `each' for nil:NilClass
```

Output from my branch:

```
   parameters:
     max_connections: 100
+  replica_method:
+    wal_g:
+      foo: bar
 
 restapi:
   listen: 0.0.0.0:8008
```