### PR TITLE
Fix crash if pg password starting with bracket

### DIFF
--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -79,10 +79,10 @@ postgresql:
   authentication:
     superuser:
       username: <%= @superuser_username %>
-      password: <%= @superuser_password %>
+      password: '<%= @superuser_password %>'
     replication:
       username: <%= @replication_username %>
-      password: <%= @replication_password %>
+      password: '<%= @replication_password %>'
 <% unless @callback_on_reload == nil && @callback_on_restart == nil && @callback_on_role_change == nil && @callback_on_start == nil && @callback_on_stop == nil -%>
   callbacks:
 <% if @callback_on_reload != nil -%>


### PR DESCRIPTION
If pg password starts with ], patroni crashs with log bellow : 

```
Jul 29 11:38:21 secret-server patroni[3831230]: Traceback (most recent call last):
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/bin/patroni", line 8, in <module>
Jul 29 11:38:21 secret-server patroni[3831230]:     sys.exit(main())
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/__init__.py", line 171, in main
Jul 29 11:38:21 secret-server patroni[3831230]:     return patroni_main()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/__init__.py", line 139, in patroni_main
Jul 29 11:38:21 secret-server patroni[3831230]:     abstract_main(Patroni, schema)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/daemon.py", line 91, in abstract_main
Jul 29 11:38:21 secret-server patroni[3831230]:     config = Config(args.configfile)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/config.py", line 99, in __init__
Jul 29 11:38:21 secret-server patroni[3831230]:     self._local_configuration = self._load_config_file()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/config.py", line 148, in _load_config_file
Jul 29 11:38:21 secret-server patroni[3831230]:     config = self._load_config_path(self._config_file)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/opt/app/patroni/lib/python3.8/site-packages/patroni/config.py", line 142, in _load_config_path
Jul 29 11:38:21 secret-server patroni[3831230]:     config = yaml.safe_load(f)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/__init__.py", line 162, in safe_load
Jul 29 11:38:21 secret-server patroni[3831230]:     return load(stream, SafeLoader)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/__init__.py", line 114, in load
Jul 29 11:38:21 secret-server patroni[3831230]:     return loader.get_single_data()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/constructor.py", line 49, in get_single_data
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.get_single_node()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 36, in get_single_node
Jul 29 11:38:21 secret-server patroni[3831230]:     document = self.compose_document()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 55, in compose_document
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.compose_node(None, None)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.compose_mapping_node(anchor)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
Jul 29 11:38:21 secret-server patroni[3831230]:     item_value = self.compose_node(node, item_key)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.compose_mapping_node(anchor)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
Jul 29 11:38:21 secret-server patroni[3831230]:     item_value = self.compose_node(node, item_key)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.compose_mapping_node(anchor)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
Jul 29 11:38:21 secret-server patroni[3831230]:     item_value = self.compose_node(node, item_key)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node
Jul 29 11:38:21 secret-server patroni[3831230]:     node = self.compose_mapping_node(anchor)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
Jul 29 11:38:21 secret-server patroni[3831230]:     item_value = self.compose_node(node, item_key)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/composer.py", line 64, in compose_node
Jul 29 11:38:21 secret-server patroni[3831230]:     if self.check_event(AliasEvent):
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/parser.py", line 98, in check_event
Jul 29 11:38:21 secret-server patroni[3831230]:     self.current_event = self.state()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/parser.py", line 451, in parse_block_mapping_value
Jul 29 11:38:21 secret-server patroni[3831230]:     return self.parse_block_node_or_indentless_sequence()
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/parser.py", line 271, in parse_block_node_or_indentless_sequence
Jul 29 11:38:21 secret-server patroni[3831230]:     return self.parse_node(block=True, indentless_sequence=True)
Jul 29 11:38:21 secret-server patroni[3831230]:   File "/usr/lib/python3/dist-packages/yaml/parser.py", line 369, in parse_node
Jul 29 11:38:21 secret-server patroni[3831230]:     raise ParserError("while parsing a %s node" % node, start_mark,
Jul 29 11:38:21 secret-server patroni[3831230]: yaml.parser.ParserError: while parsing a block node
Jul 29 11:38:21 secret-server patroni[3831230]: expected the node content, but found ']'
Jul 29 11:38:21 secret-server patroni[3831230]:   in "/etc/patroni/config.yml", line 63, column 17
Jul 29 11:38:21 secret-server systemd[1]: patroni.service: Main process exited, code=exited, status=1/FAILURE
Jul 29 11:38:21 secret-server systemd[1]: patroni.service: Failed with result 'exit-code'.
```

This PR fix the problem by enclosing password into single quote.