### PR TITLE
Fix improper parsing of pgsql_replica_method

### DIFF
--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -130,10 +130,12 @@ postgresql:
 <% end -%>
 <% unless @pgsql_replica_method.empty? -%>
   replica_method:
-<% @pgsql_replica_method.each do |name,settings| -%>
+<% @pgsql_replica_method.each do |replica_method| -%>
+<% replica_method.each do |name, settings| -%>
     <%= name -%>:
 <% settings.each do |setname,setval| -%>
       <%= setname -%>: <%= setval %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Directly parsing key and value from array of hashes won't work, we need to first iterate through array and then split key and value in each array member