### PR TITLE
update ensure_packages()->stdlib::ensure_packages()

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -469,7 +469,7 @@ class patroni (
       }
     }
 
-    ensure_packages($install_dependencies, { 'before' => Python::Pip['patroni'] })
+    stdlib::ensure_packages($install_dependencies, { 'before' => Python::Pip['patroni'] })
 
     exec { 'patroni-mkdir-install_dir':
       command => "/bin/mkdir -p ${install_dir}",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.4.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
stdlib 9 introduced the namespaced functions. The old ones raise warnings because they are deprecated.

> Warning: This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/modules/patroni/manifests/init.pp", 472]