### PR TITLE
Automatically quote string starting with %

### DIFF
--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -29,7 +29,7 @@ bootstrap:
 <% unless @dcs_postgresql_parameters.empty? -%>
       parameters:
 <% @dcs_postgresql_parameters.each do |name,val| -%>
-        <%= name -%>: <%= val %>
+        <%= name -%>: <%= val.to_s.start_with?('%') ? val.to_s.dump : val %>
 <% end -%>
 <% end -%>
   method: <%= @bootstrap_method %>


### PR DESCRIPTION
#### Pull Request (PR) description

Because patroni fails with a parser error when the first character of an unquoted string value is `%`, we patch the provider so that it quotes any strings starting with `%` for the `dcs_postgresql_parameters`.

#### This Pull Request (PR) fixes the following issues

n/a